### PR TITLE
adding node version requirement for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@fontsource/fira-mono": "^4.5.0",
     "@lukeed/uuid": "^2.0.0",
     "cookie": "^0.4.1"
+  },
+  "engines": {
+    "node": ">=16.7"
   }
 }

--- a/src/routes/gallery/album.svelte
+++ b/src/routes/gallery/album.svelte
@@ -9,10 +9,16 @@
 </script>
 
 <script lang="ts">
-	export let album: PhotoAlbum = undefined;
+	export let album: PhotoAlbum = {
+        id: 0,
+        name: "",
+        coverUri: "",
+        slug: "",
+        itemCount: 0
+    };
 </script>
 
-<a class="gallery-album" href="./gallery/{album.slug}">
+<a class="gallery-album" href="./">
     <img class="album-cover" src="{album.coverUri}" alt="cover art for {album.name}">
     <div class="album-info">
         <h3 class="album-name">{album.name}</h3>


### PR DESCRIPTION
Oryx is crashing because it had an old version of node baked in

`npm ERR! notsup Unsupported engine for @sveltejs/kit@1.0.0-next.350: wanted: {"node":">=16.7"} (current: {"node":"14.19.1","npm":"6.14.16"})
`

According to https://github.com/Azure/static-web-apps/issues/694 this should fix it:
  "engines": {
    "node": ">=16"
  }

